### PR TITLE
Fix mission ending; Tweak vehicles PFHs

### DIFF
--- a/functions/core/missionSelection.sqf
+++ b/functions/core/missionSelection.sqf
@@ -24,7 +24,7 @@ if ((!isNil "_firstCall") && {_firstCall}) Then {
 //------------------- Check if the mission amount has been reached.
 
 if ((PARAM_missionAmount > 0) && {!isNil "derp_missionCounter"} && {PARAM_missionAmount == derp_missionCounter}) then {
-    "Won" call BIS_fnc_EndMissionServer;
+    "everyonewon" call BIS_fnc_EndMissionServer;
 
 } else {
     private _nextMission = selectRandom derp_missionSelectionArray;

--- a/functions/misc/vehicle_handler/fn_quadPFH.sqf
+++ b/functions/misc/vehicle_handler/fn_quadPFH.sqf
@@ -15,7 +15,7 @@
         if (isNull _vehicle) then {
             [{
                 params ["_vehicleClass", "_spawnPos", "_spawnDir", "_timer"];
-                _newVehicle = createVehicle [_vehicleClass, _spawnPos, [], 0, "CAN_COLLIDE"];
+                _newVehicle = createVehicle [_vehicleClass, _spawnPos, [], 0, "NONE"];
                 _newVehicle setDir _spawnDir;
 
                 derp_quadHandlingArray pushBack [_newVehicle, _vehicleClass, _spawnPos, _spawnDir, _timer];
@@ -27,14 +27,19 @@
         } else {
             if (!alive _vehicle) then {
                 [{
-                    params ["_vehicleClass", "_spawnPos", "_spawnDir", "_timer"];
-                    _newVehicle = createVehicle [_vehicleClass, _spawnPos, [], 0, "CAN_COLLIDE"];
+                    params ["_oldVehicle", "_vehicleClass", "_spawnPos", "_spawnDir", "_timer"];
+
+                    if (!isNull _oldVehicle) then {
+                        deleteVehicle _oldVehicle;
+                    };
+
+                    _newVehicle = createVehicle [_vehicleClass, _spawnPos, [], 0, "NONE"];
                     _newVehicle setDir _spawnDir;
 
                     derp_quadHandlingArray pushBack [_newVehicle, _vehicleClass, _spawnPos, _spawnDir, _timer];
                     [_newVehicle] call derp_fnc_vehicleSetup;
 
-                }, [_vehicleClass, _spawnPos, _spawnDir, _timer], _timer] call derp_fnc_waitAndExec;
+                }, [_vehicle, _vehicleClass, _spawnPos, _spawnDir, _timer], _timer] call derp_fnc_waitAndExec;
                 derp_quadHandlingArray deleteAt (derp_quadHandlingArray find _x);
 
             } else {
@@ -48,7 +53,7 @@
                 if ((!isNil "_distanceCheckResult") && {_distanceCheckResult}) then {
                     [{
                         params ["_vehicleClass", "_spawnPos", "_spawnDir", "_timer"];
-                        _newVehicle = createVehicle [_vehicleClass, _spawnPos, [], 0, "CAN_COLLIDE"];
+                        _newVehicle = createVehicle [_vehicleClass, _spawnPos, [], 0, "NONE"];
                         _newVehicle setDir _spawnDir;
 
                         derp_quadHandlingArray pushBack [_newVehicle, _vehicleClass, _spawnPos, _spawnDir, _timer];

--- a/functions/misc/vehicle_handler/fn_vehiclePFH.sqf
+++ b/functions/misc/vehicle_handler/fn_vehiclePFH.sqf
@@ -19,7 +19,7 @@
                 [{
                     params ["_vehicleClass", "_spawnPos", "_spawnDir", "_timer"];
 
-                    _newVehicle = createVehicle [_vehicleClass, _spawnPos, [], 0, "CAN_COLLIDE"];
+                    _newVehicle = createVehicle [_vehicleClass, _spawnPos, [], 0, "NONE"];
                     _newVehicle setDir _spawnDir;
 
                     derp_vehicleHandlingArray pushBack [_newVehicle, _vehicleClass, _spawnPos, _spawnDir, _timer];
@@ -37,10 +37,10 @@
                             deleteVehicle _oldVehicle;
                         };
 
-                        _newVehicle = createVehicle [_vehicleClass, _spawnPos, [], 0, "CAN_COLLIDE"];
+                        _newVehicle = createVehicle [_vehicleClass, _spawnPos, [], 0, "NONE"];
                         _newVehicle setDir _spawnDir;
 
-                        derp_vehicleHandlingArray pushBack [_newVehicle,_vehicleClass, _spawnPos, _spawnDir, _timer];
+                        derp_vehicleHandlingArray pushBack [_newVehicle, _vehicleClass, _spawnPos, _spawnDir, _timer];
                         [_newVehicle] call derp_fnc_vehicleSetup;
 
                     }, [_vehicle, _vehicleClass, _spawnPos, _spawnDir, _timer], _timer] call derp_fnc_waitAndExec;
@@ -58,7 +58,7 @@
                         if ((!isNil "_distanceCheckResult") && {_distanceCheckResult}) then {
                             [{
                                 params ["_vehicleClass", "_spawnPos", "_spawnDir", "_timer"];
-                                _newVehicle = createVehicle [_vehicleClass, _spawnPos, [], 0, "CAN_COLLIDE"];
+                                _newVehicle = createVehicle [_vehicleClass, _spawnPos, [], 0, "NONE"];
                                 _newVehicle setDir _spawnDir;
 
                                 derp_vehicleHandlingArray pushBack [_newVehicle, _vehicleClass, _spawnPos, _spawnDir, _timer];


### PR DESCRIPTION
**missionSelection.sqf:**
- Fixed mission ending type

**fn_quadPFH.sqf:**
- Vehicle respawn made more safe

**fn_vehiclePFH.sqf:**
- Vehicle respawn made more safe
- Added missing space
